### PR TITLE
Fix required parsing being swapped

### DIFF
--- a/dbschema/queries/movies/movies.edgeql
+++ b/dbschema/queries/movies/movies.edgeql
@@ -7,6 +7,22 @@ INSERT Movie {
     actors := (SELECT Person FILTER contains(<array<uuid>>$person_ids, .id))
 };
 
+# name: select-movie-by-title-required!
+# Get a single movie by it's title
+SELECT Movie {
+    title,
+    year,
+    director: {
+        last_name,
+    },
+    actors: {
+        first_name,
+        last_name,
+    }
+}
+FILTER .title ILIKE <str>$title
+LIMIT 1
+
 # name: select-movie-by-title+
 # Get a single movie by it's title
 SELECT Movie {

--- a/edgeql_queries/parsing.py
+++ b/edgeql_queries/parsing.py
@@ -43,8 +43,8 @@ VALID_QUERY_NAME_PATTERN = re.compile(r"^\w+$")
 _OPERATION_SUFFFIXES_TO_TYPES: Mapping[str, EdgeQLOperationType] = MappingProxyType(
     {
         "*": EdgeQLOperationType.execute,
-        "!": EdgeQLOperationType.single_return,
-        "+": EdgeQLOperationType.required_single_return,
+        "+": EdgeQLOperationType.single_return,
+        "!": EdgeQLOperationType.required_single_return,
         "": EdgeQLOperationType.set_return,
     },
 )

--- a/tests/test_async_queries.py
+++ b/tests/test_async_queries.py
@@ -1,8 +1,28 @@
 import json
 
 import edgedb
+import pytest
 
 from edgeql_queries.queries import Queries
+
+
+async def test_selecting_required_single_object(
+    async_client: edgedb.AsyncIOExecutor,
+    async_queries: Queries,
+) -> None:
+    title_regex = "blade runner%"
+    movie = await async_queries.movies.select_movie_by_title_required(
+        async_client,
+        title=title_regex,
+    )
+    assert movie.title == "Blade Runner 2049"
+
+    title_regex = "this does not exist"
+    with pytest.raises(edgedb.errors.NoDataError):
+        await async_queries.movies.select_movie_by_title_required(
+            async_client,
+            title=title_regex,
+        )
 
 
 async def test_selecting_single_object(
@@ -15,6 +35,13 @@ async def test_selecting_single_object(
         title=title_regex,
     )
     assert movie.title == "Blade Runner 2049"
+
+    title_regex = "this does not exist"
+    movie = await async_queries.movies.select_movie_by_title(
+        async_client,
+        title=title_regex,
+    )
+    assert movie is None
 
 
 async def test_selecting_multiple_objects(

--- a/tests/test_sync_queries.py
+++ b/tests/test_sync_queries.py
@@ -1,8 +1,28 @@
 import json
 
 import edgedb
+import pytest
 
 from edgeql_queries.queries import Queries
+
+
+def test_selecting_required_single_object(
+    sync_client: edgedb.Executor,
+    sync_queries: Queries,
+) -> None:
+    title_regex = "blade runner%"
+    movie = sync_queries.movies.select_movie_by_title_required(
+        sync_client,
+        title=title_regex,
+    )
+    assert movie.title == "Blade Runner 2049"
+
+    title_regex = "this does not exist"
+    with pytest.raises(edgedb.errors.NoDataError):
+        sync_queries.movies.select_movie_by_title_required(
+            sync_client,
+            title=title_regex,
+        )
 
 
 def test_selecting_single_object(
@@ -12,6 +32,13 @@ def test_selecting_single_object(
     title_regex = "blade runner%"
     movie = sync_queries.movies.select_movie_by_title(sync_client, title=title_regex)
     assert movie.title == "Blade Runner 2049"
+
+    title_regex = "this does not exist"
+    movie = sync_queries.movies.select_movie_by_title(
+        sync_client,
+        title=title_regex,
+    )
+    assert movie is None
 
 
 def test_selecting_multiple_objects(


### PR DESCRIPTION
Although `!` was documented to be the "required" variant, it was
actually swapped with `+`, and none of the tests caught it because they
didn't test required queries. This fixes the bug and adds some tests to
ensure that they work as expected.